### PR TITLE
[Feat]:Updates reranker to expand query, adds rel-feedback adds endpoint, closes #26

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,12 +1,67 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
 
+from feedback_store import FeedbackStore
 from search.es_search import search_articles
+from search.reranker import expand_query_with_rocchio, rerank_with_rocchio
 
 
 app = FastAPI(title="News Recommendation API")
+feedback_store = FeedbackStore()
+
+
+class FeedbackRequest(BaseModel):
+    article_id: str = Field(min_length=1)
+    query: str = ""
+    feedback: Literal["like", "dislike"]
+    article: dict | None = None
+    size: int = Field(default=10, ge=1, le=50)
+
+
+def _search_with_relevance_feedback(
+    query: str,
+    size: int,
+) -> tuple[list[dict], str, list[str]]:
+    """
+    Perform a search with relevance feedback using the Rocchio algorithm.
+    Returns the list of articles, the expanded query, and the expansion terms (for logging).
+    
+    Parameters:
+        query: The original search query.
+        size: The number of articles to return.
+    Returns:
+        A tuple containing the list of articles, the expanded query, and the expansion terms.
+    """
+    
+    # Retrieve all feedback entries and their associated articles from the feedback store (eventually Elasticsearch).
+    feedback_entries = feedback_store.list_feedback()
+    feedback_articles = feedback_store.list_feedback_articles()
+    
+    # Expand the query using Rocchio based on the feedback entries and articles. 
+    expanded_query, expansion_terms = expand_query_with_rocchio(
+        query=query,
+        feedback_articles=feedback_articles,
+        feedback_entries=feedback_entries,
+    )
+    
+    # Perform a search with the expanded query.
+    articles = search_articles(query=expanded_query, size=size)
+
+    # If we have feedback, rerank the articles using Rocchio. 
+    if feedback_entries:
+        articles = rerank_with_rocchio(
+            query=query,
+            candidates=articles,
+            feedback_entries=feedback_entries,
+            feedback_articles=feedback_articles,
+        )
+
+    return articles, expanded_query, expansion_terms
 
 app.add_middleware(
     CORSMiddleware,
@@ -27,5 +82,41 @@ def get_search_results(
     query: str = Query(default="", description="Search query"),
     size: int = Query(default=10, ge=1, le=50),
 ) -> dict[str, list[dict]]:
-    articles = search_articles(query=query, size=size)
+    articles, _expanded_query, _expansion_terms = _search_with_relevance_feedback(
+        query=query,
+        size=size,
+    )
     return {"articles": articles}
+
+
+@app.post("/api/feedback")
+def post_feedback(
+    payload: FeedbackRequest,
+) -> dict[str, list[dict] | dict[str, str | int] | str | list[str]]:
+    """
+    Endpoint to receive user feedback on articles. 
+    Stores the feedback (eventually in Elasticsearch) and returns an updated search result based on the feedback.
+    """
+    
+    feedback_value = 1 if payload.feedback == "like" else -1
+    
+    # Add feedback (replace with ES)
+    entry = feedback_store.add_feedback(
+        article_id=payload.article_id,
+        query=payload.query,
+        feedback=feedback_value,
+        article=payload.article,
+    )
+
+    # Perform a search with relevance feedback to get updated results based on the new feedback.
+    articles, expanded_query, expansion_terms = _search_with_relevance_feedback(
+        query=payload.query,
+        size=payload.size,
+    )
+
+    return {
+        "feedback": entry,
+        "expanded_query": expanded_query,
+        "expansion_terms": expansion_terms,
+        "articles": articles,
+    }

--- a/backend/feedback_store.py
+++ b/backend/feedback_store.py
@@ -1,4 +1,45 @@
-class FeedbackStore:
-    """Placeholder for future Elasticsearch-backed feedback storage."""
+"""This file should be removed once we store our feedback in Elasticsearch"""
 
-    pass
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any
+
+
+class FeedbackStore:
+    """Small in-memory store with the same shape as the future ES feedback index."""
+
+    def __init__(self) -> None:
+        self._entries: list[dict[str, Any]] = []
+        self._articles_by_id: dict[str, dict[str, Any]] = {}
+        self._lock = Lock()
+
+    def add_feedback(
+        self,
+        article_id: str,
+        query: str,
+        feedback: int,
+        article: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        entry = {
+            "article_id": article_id,
+            "query": query,
+            "feedback": feedback,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        with self._lock:
+            self._entries.append(entry)
+            if article:
+                self._articles_by_id[article_id] = article
+
+        return entry
+
+    def list_feedback(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return list(self._entries)
+
+    def list_feedback_articles(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return list(self._articles_by_id.values())

--- a/backend/search/reranker.py
+++ b/backend/search/reranker.py
@@ -9,6 +9,33 @@ from search.vectorization import (
     compute_idf,
 )
 
+EXPANSION_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "this",
+    "to",
+    "was",
+    "were",
+    "with",
+}
+
 
 def _normalize_base_score(score: float, min_score: float, max_score: float) -> float:
     """
@@ -37,10 +64,95 @@ def _query_similarity(
     return cosine_similarity(left_vector, right_vector)
 
 
+def expand_query_with_rocchio(
+    query: str,
+    feedback_articles: list[dict],
+    feedback_entries: list[dict],
+    alpha: float = 1.0,
+    beta: float = 0.75,
+    gamma: float = 0.15,
+    max_expansion_terms: int = 6,
+    query_similarity_threshold: float = 0.2,
+) -> tuple[str, list[str]]:
+    """
+    Convert the Rocchio-updated query vector into extra search terms for the
+    retrieval step before reranking.
+    """
+    if not feedback_articles or not feedback_entries:
+        return query, []
+
+    document_tokens = [
+        preprocess_text(article_to_text(article)) for article in feedback_articles
+    ]
+    idf_map = compute_idf([preprocess_text(query), *document_tokens])
+    query_vector = build_query_vector(query, idf_map)
+    article_vectors = {
+        article["id"]: build_article_vector(article, idf_map)
+        for article in feedback_articles
+    }
+
+    feedback_queries = [
+        entry.get("query", "")
+        for entry in feedback_entries
+        if isinstance(entry.get("query"), str) and entry.get("query", "").strip()
+    ]
+    query_idf_map = compute_idf(
+        [preprocess_text(past_query) for past_query in [query, *feedback_queries]]
+    )
+
+    relevant_weighted_vectors: list[tuple[dict[str, float], float]] = []
+    non_relevant_weighted_vectors: list[tuple[dict[str, float], float]] = []
+
+    for entry in feedback_entries:
+        past_query = entry.get("query", "")
+        article_id = entry.get("article_id")
+        feedback_value = int(entry.get("feedback", 0))
+
+        if not isinstance(past_query, str) or article_id not in article_vectors:
+            continue
+
+        query_similarity = _query_similarity(query, past_query, query_idf_map)
+        if query.strip() and query_similarity < query_similarity_threshold:
+            continue
+
+        weight = query_similarity if query_similarity > 0 else 1.0
+        weighted_vector = (article_vectors[article_id], weight)
+        if feedback_value == 1:
+            relevant_weighted_vectors.append(weighted_vector)
+        elif feedback_value == -1:
+            non_relevant_weighted_vectors.append(weighted_vector)
+
+    updated_query_vector = weighted_rocchio_update(
+        query_vector=query_vector,
+        relevant_weighted_vectors=relevant_weighted_vectors,
+        non_relevant_weighted_vectors=non_relevant_weighted_vectors,
+        alpha=alpha,
+        beta=beta,
+        gamma=gamma,
+    )
+
+    original_terms = set(preprocess_text(query))
+    expansion_terms: list[str] = []
+    for term, _score in sorted(
+        updated_query_vector.items(), key=lambda item: item[1], reverse=True
+    ):
+        if term in original_terms or term in EXPANSION_STOPWORDS:
+            continue
+        if len(term) <= 2 or term.isdigit():
+            continue
+        expansion_terms.append(term)
+        if len(expansion_terms) == max_expansion_terms:
+            break
+
+    expanded_query = " ".join([query.strip(), *expansion_terms]).strip()
+    return expanded_query, expansion_terms
+
+
 def rerank_with_rocchio(
     query: str,
     candidates: list[dict],
     feedback_entries: list[dict],
+    feedback_articles: list[dict] | None = None,
     alpha: float = 0.5,
     beta: float = 0.5,
     gamma: float = 0.15,
@@ -68,9 +180,16 @@ def rerank_with_rocchio(
     if not candidates:
         return []
 
+    vector_articles_by_id = {
+        article["id"]: article
+        for article in [*candidates, *(feedback_articles or [])]
+        if article.get("id")
+    }
+
     # Get all tokens for IDF calculation
     document_tokens = [
-        preprocess_text(article_to_text(article)) for article in candidates
+        preprocess_text(article_to_text(article))
+        for article in vector_articles_by_id.values()
     ]
 
     # Calculate IDF values for all terms across all candidate articles and the query
@@ -79,7 +198,8 @@ def rerank_with_rocchio(
     # Build the query vector and article vectors using TF-IDF.
     query_vector = build_query_vector(query, idf_map)
     article_vectors = {
-        article["id"]: build_article_vector(article, idf_map) for article in candidates
+        article["id"]: build_article_vector(article, idf_map)
+        for article in vector_articles_by_id.values()
     }
 
     # Build a small query corpus so we can compare the current query to the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,9 +40,18 @@ function App() {
   }
 
   /* Apply relevance feedback (like/dislike) to an article and submit it to the backend */
-  async function handleFeedback(articleId: string, feedback: Exclude<Feedback, null>) {
+  async function handleFeedback(article: Article, feedback: Exclude<Feedback, null>) {
+    const articleId = article.id;
     setFeedbackById((current) => ({ ...current, [articleId]: feedback }));
-    await submitFeedback(articleId, feedback);
+
+    try {
+      const response = await submitFeedback(article, feedback, query, articles.length || 10);
+      setArticles(response.articles);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to submit feedback right now."
+      );
+    }
   }
 
   /* Calculate the total number of likes and dislikes based on the feedback state */
@@ -123,14 +132,14 @@ function App() {
                     <button
                       type="button"
                       className={feedback === "like" ? "active positive" : ""}
-                      onClick={() => void handleFeedback(article.id, "like")}
+                      onClick={() => void handleFeedback(article, "like")}
                     >
                       Like
                     </button>
                     <button
                       type="button"
                       className={feedback === "dislike" ? "active negative" : ""}
-                      onClick={() => void handleFeedback(article.id, "dislike")}
+                      onClick={() => void handleFeedback(article, "dislike")}
                     >
                       Dislike
                     </button>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -33,13 +33,34 @@ export async function fetchRecommendations(query: string): Promise<SearchRespons
 }
 
 /***
- * Submit user feedback (like/dislike) for a specific article (currently just logs the feedback)
- * @param articleId - The ID of the article for which feedback is being submitted
- * @param feedback - The feedback value ("like" or "dislike")
- * @returns A promise that resolves when the feedback has been "submitted"
- * Note: In a real implementation, this would involve an API call to the backend to record the feedback
+ * Submit user feedback and receive the reranked recommendation list.
  */
-export async function submitFeedback(articleId: string, feedback: Feedback): Promise<void> {
-  console.info("Feedback submitted", { articleId, feedback });
-  return Promise.resolve();
+export async function submitFeedback(
+  article: Article,
+  feedback: Exclude<Feedback, null>,
+  query: string,
+  size: number
+): Promise<SearchResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/feedback`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      article_id: article.id,
+      article,
+      feedback,
+      query,
+      size,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Feedback request failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as SearchResponse;
+  return {
+    articles: Array.isArray(payload.articles) ? payload.articles : [],
+  };
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -8,4 +8,7 @@ export interface Article {
   topic: string;
   publishedAt: string;
   url: string;
+  base_score?: number;
+  feedback_score?: number;
+  final_score?: number;
 }


### PR DESCRIPTION
## Summary

This PR adds an end-to-end relevance feedback loop for article recommendations (with missing second ES index for persistently storing relevance feedback).

Users can now like or dislike articles in the GUI, and the backend uses that feedback to adjust recommendations using Rocchio-based query expansion and reranking.

## Additions
- Added a `POST /api/feedback` endpoint.
- Added an in-memory `FeedbackStore` for feedback events and clicked article snapshots (eventually obsolete).
- Updated the frontend to send feedback to the backend when a user clicks **Like** or **Dislike**.
- Added Rocchio-based query expansion before Elasticsearch retrieval.
- Updated backend search flow to rerank returned candidates using accumulated relevance feedback.
- Updated article types to include optional ranking scores.

## Feedback Flow
Below is the current flow:

```text
1. User searches for articles, for example "iran".
2. Backend retrieves matching article candidates from Elasticsearch.
3. User clicks Like or Dislike on an article.
4. Frontend sends the feedback plus the clicked article info to POST /api/feedback.
5. Backend stores the feedback event in memory:
   - like -> +1
   - dislike -> -1
6. Backend stores the clicked article snapshot in memory (this should be replace).
7. Rocchio uses the original query, liked articles, and disliked articles to build an updated query vector.
8. Backend extracts the strongest new terms from that vector as query expansion terms.
9. Backend searches Elasticsearch again using the expanded query.
10. Backend reranks the new candidate pool using Rocchio feedback scores.
11. Frontend receives the updated article list and re-renders the recommendations.
```

## Current Storage Behavior

Feedback storage is in-memory for now.

```text
Elasticsearch:
  stores and searches article documents

In-memory FeedbackStore:
  stores feedback events and clicked article snapshots
```

Because feedback is in memory, feedback state resets whenever the backend restarts.

To persist feedback, replace the current in-memory `FeedbackStore` with an Elasticsearch-backed feedback store (@terahidro2003 is working on this).

### Possible Elasticsearch Setup

Add a second Elasticsearch index, separate from the article index:

```text
news_articles
  stores article documents

news_feedback
  stores feedback events
```

A feedback document should look like:

```json
{
  "user_id": "demo-user",
  "article_id": "abc123",
  "query": "technology",
  "feedback": 1,
  "timestamp": "2026-04-15T10:15:00Z"
}
```

### What Needs To Be Replaced

Replace this in-memory behavior:

```python
feedback_store.add_feedback(...)
feedback_store.list_feedback()
feedback_store.list_feedback_articles()
```
with Elasticsearch-backed methods.
